### PR TITLE
🛠️ Admin tools - Users managment - Step 1

### DIFF
--- a/backend_ecoride/config/packages/security.yaml
+++ b/backend_ecoride/config/packages/security.yaml
@@ -37,6 +37,9 @@ security:
         - { path: ^/api/auth/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/logout, roles: ROLE_USER }
 
+        - { path: ^/api/admin, roles: ROLE_ADMIN }
+        - { path: ^/api, roles: ROLE_USER }
+
 when@test:
     security:
         password_hashers:

--- a/backend_ecoride/src/Controller/AdminController.php
+++ b/backend_ecoride/src/Controller/AdminController.php
@@ -4,7 +4,8 @@ namespace App\Controller;
 
 use App\DTO\User\{UserDTO, UserReadDTO};
 use App\Service\Admin\{
-    CreateUserService
+    CreateUserService,
+    BanUserService
 };
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpFoundation\{Request, JsonResponse};
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
-use Symfony\Component\HttpKernel\Exception\{BadRequestHttpException, ConflictHttpException};
+use Symfony\Component\HttpKernel\Exception\{NotFoundHttpException, BadRequestHttpException, ConflictHttpException};
 use Symfony\Component\Serializer\Annotation\Context;
 
 #[Route('/api/admin', name: 'app_api_admin_')]
@@ -63,6 +64,68 @@ final class AdminController extends AbstractController
             return new JsonResponse(
                 data: ['error' => $e->getMessage()],
                 status: JsonResponse::HTTP_CONFLICT
+            );
+        }
+    }
+
+    #[Route('/ban-user', name: 'ban_user', methods: 'POST')]
+    public function banUser(
+        Request $request,
+        BanUserService $banUserService
+    ): JsonResponse {
+        try {
+            $userUuid = $request->query->get('userUuid', null);
+            if (!$userUuid) {
+                throw new BadRequestHttpException("userUuid is required");
+            }
+
+            $banUserService->banUser($userUuid);
+
+            return new JsonResponse(
+                data: ['message' => 'User successfully banned'],
+                status: JsonResponse::HTTP_OK
+            );
+
+        } catch (NotFoundHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_NOT_FOUND
+            );
+        } catch (BadRequestHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_BAD_REQUEST
+            );
+        }
+    }
+
+    #[Route('/unban-user', name: 'unban_user', methods: 'POST')]
+    public function unbanUser(
+        Request $request,
+        BanUserService $banUserService
+    ): JsonResponse {
+        try {
+            $userUuid = $request->query->get('userUuid', null);
+            if (!$userUuid) {
+                throw new BadRequestHttpException("userUuid is required");
+            }
+
+            $banUserService->unbanUser($userUuid);
+
+            return new JsonResponse(
+                data: ['message' => 'User successfully unbanned'],
+                status: JsonResponse::HTTP_OK
+            );
+
+        } catch (NotFoundHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_NOT_FOUND
+            );
+        } catch (BadRequestHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_BAD_REQUEST
             );
         }
     }

--- a/backend_ecoride/src/Controller/AdminController.php
+++ b/backend_ecoride/src/Controller/AdminController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\User\{UserDTO, UserReadDTO};
+use App\Service\Admin\{
+    CreateUserService
+};
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\{Request, JsonResponse};
+
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+
+use Symfony\Component\HttpKernel\Exception\{BadRequestHttpException, ConflictHttpException};
+use Symfony\Component\Serializer\Annotation\Context;
+
+#[Route('/api/admin', name: 'app_api_admin_')]
+final class AdminController extends AbstractController
+{
+    public function __construct(
+        private SerializerInterface $serializer,
+    ) {}
+
+    #[Route('/create-user', name: 'create_user', methods: 'POST')]
+    public function createUser(
+        Request $request,
+        CreateUserService $createUserService
+
+    ): JsonResponse {
+        try {
+            try {
+                $userCreateDTO = $this->serializer->deserialize(
+                    data: $request->getContent(),
+                    type: UserDTO::class,
+                    format: 'json'
+                );
+            } catch (\Exception $e) {
+                throw new BadRequestHttpException("Invalid JSON format");
+            }
+
+            $userReadDTO = $createUserService->createUser($userCreateDTO);
+
+            $responseData = $this->serializer->serialize(
+                data: $userReadDTO,
+                format: 'json',
+                context: ['groups' => ['user:read', 'user:create']]
+            );
+
+            return new JsonResponse(
+                data: $responseData,
+                status: JsonResponse::HTTP_CREATED,
+                json: true
+            );
+
+        } catch (BadRequestHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_BAD_REQUEST
+            );
+        } catch (ConflictHttpException $e) {
+            return new JsonResponse(
+                data: ['error' => $e->getMessage()],
+                status: JsonResponse::HTTP_CONFLICT
+            );
+        }
+    }
+}
+
+?>

--- a/backend_ecoride/src/DTO/User/UserReadDTO.php
+++ b/backend_ecoride/src/DTO/User/UserReadDTO.php
@@ -36,6 +36,9 @@ class UserReadDTO
     #[Groups(['user:read'])]
     public string $apiToken;
 
+    #[Groups(['user:create'])]
+    public ?string $plainPassword;
+
     public function __construct(
         string $uuid,
         string $pseudo,
@@ -46,6 +49,7 @@ class UserReadDTO
         DateTimeImmutable $createdAt,
         ?DateTimeImmutable $updatedAt = null,
         string $apiToken,
+        ?string $plainPassword,
     )
     {
         $this->uuid = $uuid;
@@ -57,9 +61,10 @@ class UserReadDTO
         $this->createdAt = $createdAt;
         $this->updatedAt = $updatedAt;
         $this->apiToken = $apiToken;
+        $this->plainPassword = $plainPassword;
     }
 
-    public static function fromEntity(User $user): self
+    public static function fromEntity(User $user, ?string $plainPassword = null): self
     {
         $userDTO = new self(
             uuid: $user->getUuid(),
@@ -70,7 +75,8 @@ class UserReadDTO
             isBanned: $user->isBanned(),
             createdAt: $user->getCreatedAt(),
             updatedAt: $user->getUpdatedAt(),
-            apiToken: $user->getApiToken()
+            apiToken: $user->getApiToken(),
+            plainPassword: $plainPassword,
         );
 
         return $userDTO;

--- a/backend_ecoride/src/Repository/UserRepository.php
+++ b/backend_ecoride/src/Repository/UserRepository.php
@@ -43,6 +43,11 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $this->findOneBy(['uuid' => $uuid]);
     }
 
+    public function isExistingUser(string $email): bool
+    {
+        return $this->findOneByEmail($email) !== null;
+    }
+
     //    /**
     //     * @return User[] Returns an array of User objects
     //     */

--- a/backend_ecoride/src/Service/Admin/BanUserService.php
+++ b/backend_ecoride/src/Service/Admin/BanUserService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Service\Admin;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use DateTimeImmutable;
+
+class BanUserService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository
+    ) {}
+
+    public function banUser(string $uuid): void
+    {
+        $user = $this->userRepository->findOneByUuid($uuid);
+        if (!$user) {
+            throw new NotFoundHttpException("User not found or does not exist");
+        }
+
+        $user->setIsBanned(true);
+        $user->setUpdatedAt(new DateTimeImmutable());
+
+        $this->entityManager->flush();
+    }
+
+    public function unbanUser(string $uuid): void
+    {
+        $user = $this->userRepository->findOneByUuid($uuid);
+        if (!$user) {
+            throw new NotFoundHttpException("User not found or does not exist");
+        }
+        $user->setIsBanned(false);
+        $user->setUpdatedAt(new DateTimeImmutable());
+
+        $this->entityManager->flush();
+    }
+}
+
+
+?>

--- a/backend_ecoride/src/Service/Admin/CreateUserService.php
+++ b/backend_ecoride/src/Service/Admin/CreateUserService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Service\Admin;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+
+use App\Service\{ValidationService, Utils, StringHelper};
+
+use App\DTO\User\{UserDTO, UserReadDTO};
+
+use Doctrine\ORM\EntityManagerInterface;
+
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+use DateTimeImmutable;
+
+class CreateUserService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+        private UserPasswordHasherInterface $passwordHasher,
+        private ValidationService $validationService,
+
+        private StringHelper $stringHelper,
+    ) {}
+
+    public function createUser(UserDTO $userCreateDTO): UserReadDTO
+    {
+        $this->validationService->validate($userCreateDTO, ['create']);
+
+        $email = $this->stringHelper->generateEmail($userCreateDTO->pseudo);
+
+        if ($this->userRepository->isExistingUser($email)) {
+            throw new ConflictHttpException("User already exist");
+        }
+
+        $plainPassword = Utils::randomPassword();
+
+        $user = new User();
+        $user->setPseudo($userCreateDTO->pseudo)
+             ->setEmail($email)
+             ->setRoles(['ROLE_EMPLOYEE'])
+             ->setIsBanned(false)
+             ->setCreatedAt(new DateTimeImmutable())
+             ->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return UserReadDTO::fromEntity($user, $plainPassword);
+    }
+}
+
+?>

--- a/backend_ecoride/src/Service/Utils.php
+++ b/backend_ecoride/src/Service/Utils.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Service;
+
+class Utils
+{
+    public static function randomPassword() {
+        return bin2hex(random_bytes(8));
+    }
+}
+
+?>


### PR DESCRIPTION
## 🛠️ Admin tools - Users managment - Step 1

Allows a user with the ``ROLE_ADMIN`` to manage user accounts via endpoints restricted to his role

## ✅ Added content (3 commit)

### Employee creation by admin
- Add service ``CreateUserService`` used in ``AdminController``

### Ban / Unban a user
- Add service ``BanUserService`` used in ``AdminController``
- Change the entity User ``isBanned`` property to ``true`` or ``false``
- ``/api/admin/ban-user?userUuid=`` - Ban the user
- ``/api/admin/unban-user?userUuid=`` - Unban the user

### Restricted endpoint for admin
- Update the ``service.yaml`` to restrict endpoint ``/api/admin`` for **``ROLE_ADMIN`` only**

## 🎯 Goals
Create an initial admin managment tool including :
- Create user
- Ban user
- Unban user
- Clear separation of responsibilities based on SRP (Service, Controller)

## 💹 Checklist
 - [x] Fonctionnal create user service
 - [x] Tested ban / unban
 - [x] Secured (restricted) endpoints
 - [x] Tested throwable exceptions

## 🚀 Next step
- Register system for users (visitor -> user) with endpoint ``/api/auth/register``
- Check during authentication if a user is banned in wich case the auth will be refused with error message and status code 403